### PR TITLE
Update README.md - changed CoreServices path

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ macOS versions **older** than Monterey:
 
 Monterey and later:
 ```bash
-~/systemmount/Library/CoreServices/Dock.app/Contents/Resources/DockMenus.plist
+~/systemmount/System/Library/CoreServices/Dock.app/Contents/Resources/DockMenus.plist
 ```
 <sub>Thank you [@journey-ad](https://github.com/journey-ad) for the feedback for Sequoia.</sub>
 


### PR DESCRIPTION
Path was correct in step 4, but in step 3 it was missing "/System"  
(btw this still works on Sequoia 15.4) 